### PR TITLE
Add 1.0.1 changelog and version bump

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -11,6 +11,9 @@ The plugin version number needs to be updated in the following files:
 - [`plugin.php`](/plugin.php)
 - [`readme.txt`](/readme.txt)
 
+### Update the `tested up to` version
+
+Before each release, a good practice is to test the plugin with the latest major version of WordPress. After testing, the `tested up to` version in the [`readme.txt`](/readme.txt) and [`plugin.php`](/plugin.php) files should be updated.
 ### Update the changelog
 
 In the [`readme.txt`](/readme.txt) file, update the changelog for the new version.

--- a/plugin.php
+++ b/plugin.php
@@ -2,9 +2,9 @@
 /**
  * Plugin Name:       Missed Scheduled Posts Publisher by WPBeginner
  * Description:       Catches scheduled posts that have been missed and publishes them.
- * Version:           1.0.0
+ * Version:           1.0.1
  * Requires at least: 5.0
- * Tested up to:      5.8
+ * Tested up to:      6.0
  * Requires PHP:      5.6
  * Author:            WPBeginner
  * Author URI:        https://www.wpbeginner.com/

--- a/readme.txt
+++ b/readme.txt
@@ -1,8 +1,8 @@
 === Missed Scheduled Posts Publisher by WPBeginner ===
 
-Stable tag:        1.0.0
+Stable tag:        1.0.1
 Requires at least: 5.0
-Tested up to:      5.8
+Tested up to:      6.0
 Requires PHP:      5.6
 License:           GPLv2
 Tags:              Scheduled posts, Missed schedule, Cron

--- a/readme.txt
+++ b/readme.txt
@@ -85,3 +85,10 @@ Missed Scheduled Posts Publisher is a set-and-forget plugin. There are no settin
 = 1.1.0 =
 
 * Initial plugin release.
+
+== 1.0.1 ==
+
+* Improvement: Add a new filter `wpb_missed_scheduled_posts_publisher_frequency` to allows developers to change the frequency of the plugin checks.
+* Test: Add PHP unit tests for the `wpb_missed_scheduled_posts_publisher_frequency` filter.
+* Docs: Add new documentation for the plugin release process.
+* Miscs: Update the plugin package name and description in composer.json.


### PR DESCRIPTION
This PR adds the changelog for the plugin v1.0.1 and bump the different version numbers.